### PR TITLE
Fix/meta embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,11 +810,13 @@ Example:
             ]
         },
         "_embedded": {
-            "_meta": {
-                "embedded_something": {
-                    "_ref": [
-                        "something_else"
-                    ]
+            "item": {
+                "_meta": {
+                    "embedded_something": {
+                        "_ref": [
+                            "something_else"
+                        ]
+                    }
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -808,15 +808,15 @@ Example:
                 "data1",
                 "something"
             ]
-        },
-        "_embedded": {
-            "item": {
-                "_meta": {
-                    "embedded_something": {
-                        "_ref": [
-                            "something_else"
-                        ]
-                    }
+        }
+    },
+    "_embedded": {
+        "item": {
+            "_meta": {
+                "embedded_something": {
+                    "_ref": [
+                        "something_else"
+                    ]
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -858,15 +858,17 @@ would be interpreted as:
         }
     },
     "_embedded": {
-        "_meta": {
-            "embedded_something": {
-                "options": [
-                    0,
-                    1,
-                    2
-                ],
-                "max": 1,
-                "value": 2
+        "item": {
+            "_meta": {
+                "embedded_something": {
+                    "options": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "max": 1,
+                    "value": 2
+                }
             }
         }
     }


### PR DESCRIPTION
Previously, under "_embedded", the reserved key "_meta" was used instead of property names and values that are either a Resource Object or an array of Resource Objects.

Also made a develop branch.

ping @sheavalentine-mdsol 
